### PR TITLE
Swallow errors in db:stop

### DIFF
--- a/tools/stopDevDatabase.sh
+++ b/tools/stopDevDatabase.sh
@@ -1,2 +1,2 @@
-docker kill postgres
-docker rm postgres
+docker kill postgres || true
+docker rm postgres || true


### PR DESCRIPTION
`yarn db:stop` should always fail gracefully.