### PR TITLE
Automatic login for voting

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "handlebars-loader": "^1.4.0",
     "history": "^4.5.0",
     "isomorphic-style-loader": "^1.1.0",
-    "jsonwebtoken": "^7.2.1",
+    "jsonwebtoken": "^7.3.0",
     "mime": "^1.3.4",
     "moment": "^2.17.1",
     "node-fetch": "^1.6.3",

--- a/src/config.js
+++ b/src/config.js
@@ -32,29 +32,12 @@ export const AWS_SES = {
 };
 
 export const analytics = {
-
   // https://analytics.google.com/
   google: {
     trackingId: process.env.GOOGLE_TRACKING_ID, // UA-XXXXX-X
   },
-
 };
 
 export const auth = {
-
-  jwt: { secret: process.env.JWT_SECRET || '8Q)$T(J&8yjwohiwhsu9hg09jgazdioafadgsfg)' },
-
-  facebook: {
-    id: process.env.FACEBOOK_APP_ID,
-    secret: process.env.FACEBOOK_APP_SECRET,
-  },
-  google: {
-    id: process.env.GOOGLE_CLIENT_ID,
-    secret: process.env.GOOGLE_CLIENT_SECRET,
-  },
-  twitter: {
-    key: process.env.TWITTER_CONSUMER_KEY,
-    secret: process.env.TWITTER_CONSUMER_SECRET,
-  },
-
+  jwt: { secret: process.env.JWT_SECRET },
 };

--- a/src/core/email.js
+++ b/src/core/email.js
@@ -2,7 +2,7 @@
 import { createTransport } from 'nodemailer';
 import { AWS_SES } from '../config';
 
-export const sendEmail = async (recipient, subject, html) => {
+const sendEmail = async (recipient, subject, html) => {
   const mailOptions = {
     html,
     from: 'Community Fund <hello@communityfund.co>',

--- a/src/data/mutations/createSubmission.js
+++ b/src/data/mutations/createSubmission.js
@@ -12,7 +12,7 @@ import sendEmail from '../../core/email';
 export const sendEmailToReviewer = async (reviewer, submission) => {
   log('Sending grant review email', reviewer.email, submission.Id);
 
-  const expiresIn = 60 * 60 * 24 * 15; // 10 days
+  const expiresIn = 60 * 60 * 24 * 15; // 15 days
   const token = jwt.sign(
     {
       id: reviewer.id,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3712,7 +3712,7 @@ jsonpointer@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
 
-jsonwebtoken@^7.2.1:
+jsonwebtoken@^7.3.0:
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-7.3.0.tgz#85118d6a70e3fccdf14389f4e7a1c3f9c8a9fbba"
   dependencies:


### PR DESCRIPTION
Appends a token=<token> query parameter to the link that we send to the reviewers.

I decide to plug into the current authentication scheme that uses JWT. 

The flow is as follow:

1. Generate a token that lasts for 15 days and passes along in the email.
2. When the server detects the token parameter and no cookie it will add the cookie (but only for 15 minutes).

Both the token and cookie are relatively short lived. If we would want to revoke them it would be easiest to just change the JWT secret.

## How do I test this?

1. Submit a grant application
2. Look at the links that get printed out in the console. Locally they use 3000 as the port. Change the port to 3001 and open the link in the browser. I couldn't figure out why we both run in 3000 and 3001.
3. Vote.
