### PR TITLE
Fix missing --release flag when building for deployment

### DIFF
--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -1,6 +1,6 @@
 set -e
 
-yarn build --release
+yarn build -- --release
 cd build && zip -r -X "../payload.zip" * && cd ..
 
 eb deploy communityfund-production --staged


### PR DESCRIPTION
I noticed that CommunityFund.co was behaving weirdly and the javascript wasn't minified.

Further investigation revealed that I had incorrectly passed along the `--release` flag to `yarn build`