### PR TITLE
Add basic Sketch document

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ ncp-debug.log
 npm-debug.log
 
 .env
-*/.DS_STORE
+.DS_Store
 
 # Elastic Beanstalk Files
 .elasticbeanstalk/*


### PR DESCRIPTION
Adds a basic Sketch document that contains most of frontpage and the grant form page. 

This will probably make it slightly easier to try to unify the look and create nicer subpages.